### PR TITLE
Fixed building of apptainer images (at least on FAI cluster).

### DIFF
--- a/Apptainer.asnets.learn
+++ b/Apptainer.asnets.learn
@@ -40,6 +40,10 @@ Stage: build
     # Install PySAT
     pip3 install python-sat[pblib,aiger]
 
+    cd asnets
+    python3 setup.py build
+    cd ..
+
 # Stage 2: Run the planner
 Bootstrap: docker
 From: ubuntu:22.04

--- a/Apptainer.asnets.plan
+++ b/Apptainer.asnets.plan
@@ -40,6 +40,10 @@ Stage: build
     # Install PySAT
     pip3 install python-sat[pblib,aiger]
 
+    cd asnets
+    python3 setup.py build
+    cd ..
+
 # Stage 2: Run the planner
 Bootstrap: docker
 From: ubuntu:22.04

--- a/asnets/setup.py
+++ b/asnets/setup.py
@@ -9,7 +9,8 @@ from setuptools.command.develop import develop
 from setuptools.command.install import install
 from setuptools.dist import Distribution
 
-TF_REQUIRE = 'tensorflow>=2.9.0,<3.0.0'
+TF_REQUIRE = 'tensorflow==2.11.1'
+
 
 def _build_ext(ext_obj):
     """Build C/C++ implementation of ASNet-specific TF ops."""
@@ -24,7 +25,8 @@ def _build_ext(ext_obj):
     # Tests still pass with -Ofast, and it gives marginal speed improvement, so
     # I'm leaving it on. Might revisit later. Also revisit -march=native, which
     # will probably make distribution & Dockerisation a pain.
-    extra_flags = ['-march=native', '-Ofast']
+    #extra_flags = ['-march=native', '-Ofast']
+    extra_flags = ['-Ofast']
     objects = compiler.compile(
         [src],
         debug=True,

--- a/ssipp-solver/build.py
+++ b/ssipp-solver/build.py
@@ -718,13 +718,13 @@ def main():
 
     global C_COMPILER
     C_COMPILER = args.c_compiler
-    c_flags = ['-Wall', '-march=native', '-fno-lto']
+    c_flags = ['-Wall', '-fno-lto']
 
     global CPP_COMPILER
     CPP_COMPILER = args.cpp_compiler
 
     cpp_flags = [
-        '-Wall', '-DATOM_STATES', '-march=native', '-std=c++14', '-I./',
+        '-Wall', '-DATOM_STATES', '-std=c++14', '-I./',
         '-fdiagnostics-color=always', '-fno-lto'
     ]
     if args.cpp_flags is not None:


### PR DESCRIPTION
1. Removed -march=native from submodules because it may cause some problems when the image is built on a different machine than it is later run.

2. Remove binary file asnets/asnets/ops/_asnet_ops_impl.so which shouldn't have been part of the repo in the first place and updated apptainer recipes so that this python module is built.

3. Fixed tensorflow version to something that works.